### PR TITLE
fix: schedule renovate to run weekly

### DIFF
--- a/config/renovate.json
+++ b/config/renovate.json
@@ -40,6 +40,7 @@
     "rebaseWhen": "behind-base-branch",
     "recreateWhen": "always"
   },
+  "minimumReleaseAge": "2 days",
   "packageRules": [
     {
       "branchTopic": "all",
@@ -62,6 +63,8 @@
   "prConcurrentLimit": 1,
   "rangeStrategy": "update-lockfile",
   "recreateWhen": "always",
+  "schedule": ["before 4am on monday"],
   "separateMajorMinor": false,
-  "separateMinorPatch": false
+  "separateMinorPatch": false,
+  "timezone": "UTC"
 }


### PR DESCRIPTION
- run on Monday's before we start working
- require at least 2 days age for releases to avoid bad releases
