### PR TITLE
fix: prevent untrusted code checkout in sonar job

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -57,7 +57,10 @@ jobs:
           }
   sonar:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event != 'pull_request' ||
+       github.event.workflow_run.head_repository.full_name == github.repository)
     steps:
       - name: Debug
         run: |


### PR DESCRIPTION
Guard the sonar job against fork PRs to avoid checking out untrusted code in a privileged workflow_run context with access to secrets (SONAR_TOKEN, GITHUB_TOKEN).