### PR TITLE
fix: apply tombi formatting to prek.toml

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -109,7 +109,12 @@ language = "node"
 language_version = "24"
 pass_filenames = false
 files = {
-  glob = ["package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml"]
+  glob = [
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+  ]
 }
 stages = ["manual"]
 entry = "sh -c 'npx ncu && npm ci'"


### PR DESCRIPTION
Apply the toml formatter's preferred style to prek.toml so the lint hook no longer reports a dirty worktree on main. Restores CI health.

Failing run: https://github.com/ansible/actions/actions/runs/29461457068/job/87505767157

Assisted by Claude Code.